### PR TITLE
Fix for btpair application not disabling mission control event redirection when terminated via home button press

### DIFF
--- a/btpair/source/bt_pairing_manager.cpp
+++ b/btpair/source/bt_pairing_manager.cpp
@@ -29,13 +29,6 @@ Result BtPairingManager::Initialize()
 {
     Result rc;
 
-    rc = btdrvInitialize();
-
-    if (R_FAILED(rc)) {
-        TRACE("[!] btdrvInitialize %x\n", rc);
-        return rc;
-    }
-
     // TODO: If mission control is not installed, this will force terminate the IPC session.
     rc = btdrvMissionControlRedirectCoreEvents(true);
 
@@ -57,6 +50,14 @@ Result BtPairingManager::Initialize()
     m_state = PairingState::Ready;
     m_is_initialized = true;
     return rc;
+}
+
+void BtPairingManager::Finalize()
+{
+    if (m_is_initialized) {
+        eventClose(&m_btevent);
+        btdrvMissionControlRedirectCoreEvents(false);
+    }
 }
 
 Result BtPairingManager::BeginScan()
@@ -221,9 +222,5 @@ const char* BtPairingManager::GetState()
 
 BtPairingManager::~BtPairingManager()
 {
-    if (m_is_initialized) {
-        eventClose(&m_btevent);
-        btdrvMissionControlRedirectCoreEvents(false);
-        btdrvExit();
-    }
+
 }

--- a/btpair/source/bt_pairing_manager.h
+++ b/btpair/source/bt_pairing_manager.h
@@ -22,6 +22,7 @@ class BtPairingManager {
 public:
     BtPairingManager();
     Result Initialize();
+    void Finalize();
     Result BeginScan();
     void PollEvents();
     void Pair(BtdrvAddress addr);

--- a/btpair/source/main.cpp
+++ b/btpair/source/main.cpp
@@ -37,6 +37,8 @@ static const char* Header =
 
 int main(int argc, char *argv[])
 {
+    appletLockExit();
+    
     consoleInit(NULL);
     padConfigureInput(1, HidNpadStyleSet_NpadStandard);
 
@@ -132,7 +134,10 @@ int main(int argc, char *argv[])
         consoleUpdate(NULL);
     }
 
+    g_pairing_manager.Finalize();
+
     btdrvExit();
     consoleExit(NULL);
+    appletUnlockExit();
     return 0;
 }


### PR DESCRIPTION
This adds calls to `appletLockExit`/`appletUnlockExit` and moves cleanup code into a Finalize function to allow proper cleanup and disable mission control's event redirection before termination when the user exits via the home button. I believe that without this the application is force-terminated when the home button is pressed and the code in the `BtPairingManager` destructor is never run.

I suspect this may be the cause of the crash-on-sleep issues people have been reporting.